### PR TITLE
Rust: Refactor Tags Struct

### DIFF
--- a/rust/osm2lanes/Cargo.toml
+++ b/rust/osm2lanes/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 authors = ["Dustin Carlino <dabreegster@gmail.com>"]
 
 [dependencies]
-serde = { version = "1", features=["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/osm2lanes/src/lib.rs
+++ b/rust/osm2lanes/src/lib.rs
@@ -146,7 +146,8 @@ impl LanePrintable for Direction {
     }
 }
 
-/// Internal convenience functions around a string->string map
+/// A map from string keys to string values. This makes copies of strings for 
+/// convenience; don't use in performance sensitive contexts.
 #[derive(Clone, Deserialize)]
 pub struct Tags(BTreeMap<String, String>);
 

--- a/rust/osm2lanes/src/main.rs
+++ b/rust/osm2lanes/src/main.rs
@@ -1,10 +1,7 @@
-use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufReader, Write};
 
-use serde::Deserialize;
-
-use osm2lanes::{get_lane_specs_ltr, Config, DrivingSide};
+use osm2lanes::{get_lane_specs_ltr, Config, DrivingSide, Tags};
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -12,10 +9,10 @@ fn main() {
         panic!("Usage: osm2lanes INPUT_FILE OUTPUT_FILE");
     }
 
-    let input: Tags =
+    let tags: Tags =
         serde_json::from_reader(BufReader::new(File::open(&args[1]).unwrap())).unwrap();
     let lanes = get_lane_specs_ltr(
-        input.0,
+        tags,
         &Config {
             driving_side: DrivingSide::Right,
             inferred_sidewalks: true,
@@ -24,6 +21,3 @@ fn main() {
     let mut file = File::create(&args[2]).unwrap();
     writeln!(file, "{}", serde_json::to_string_pretty(&lanes).unwrap()).unwrap();
 }
-
-#[derive(Deserialize)]
-struct Tags(BTreeMap<String, String>);

--- a/rust/osm2lanes/src/transform.rs
+++ b/rust/osm2lanes/src/transform.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::iter;
 
 use crate::{BufferType, Config, Direction, DrivingSide, LaneSpec, LaneType, Tags};
@@ -6,8 +5,7 @@ use crate::{BufferType, Config, Direction, DrivingSide, LaneSpec, LaneType, Tags
 const HIGHWAY: &str = "highway";
 
 /// From an OpenStreetMap way's tags, determine the lanes along the road from left to right.
-pub fn get_lane_specs_ltr(tags: BTreeMap<String, String>, cfg: &Config) -> Vec<LaneSpec> {
-    let tags = Tags::new(tags);
+pub fn get_lane_specs_ltr(tags: Tags, cfg: &Config) -> Vec<LaneSpec> {
     let fwd = |lane_type: LaneType| LaneSpec {
         lane_type,
         direction: Direction::Forward,


### PR DESCRIPTION
Regroup Tags to be part of the public interface, as it appears to be widely used.