### PR TITLE
Rust: Prepare for Rountrip Testing

### DIFF
--- a/rust/osm2lanes/src/lib.rs
+++ b/rust/osm2lanes/src/lib.rs
@@ -228,8 +228,6 @@ mod tests {
 
     #[test]
     fn test_from_data() {
-        // TODO This is brittle, depends on running the test from the right directory. Use
-        // include_str?
         let tests: Vec<TestCase> =
             serde_json::from_reader(BufReader::new(File::open("../../data/tests.json").unwrap()))
                 .unwrap();
@@ -271,8 +269,6 @@ mod tests {
 
     #[test]
     fn test_roundtrip() {
-        // TODO This is brittle, depends on running the test from the right directory. Use
-        // include_str?
         let tests: Vec<TestCase> =
             serde_json::from_reader(BufReader::new(File::open("../../data/tests.json").unwrap()))
                 .unwrap();

--- a/rust/osm2lanes/src/transform.rs
+++ b/rust/osm2lanes/src/transform.rs
@@ -485,3 +485,38 @@ fn osm_separation_type(x: &str) -> Option<BufferType> {
         _ => None,
     }
 }
+
+pub fn lanes_to_tags(lanes: &[LaneSpec], _cfg: &Config) -> Result<Tags, LaneSpecError> {
+    let mut tags = std::collections::BTreeMap::new();
+    tags.insert("highway".to_owned(), "yes".to_owned()); // TODO, what?
+    {
+        let lane_count = lanes
+            .iter()
+            .filter(|lane| lane.lane_type == LaneType::Driving)
+            .count();
+        tags.insert("lanes".to_owned(), lane_count.to_string());
+    }
+    if lanes
+        .iter()
+        .filter(|lane| lane.lane_type == LaneType::Driving)
+        .all(|lane| lane.direction == Direction::Forward)
+    {
+        tags.insert("oneway".to_owned(), "yes".to_owned());
+    }
+    if lanes.first().unwrap().lane_type == LaneType::Sidewalk
+        && lanes.first().unwrap().lane_type == LaneType::Sidewalk
+    {
+        tags.insert("sidewalk".to_owned(), "both".to_string());
+    }
+    if lanes
+        .iter()
+        .skip_while(|lane| lane.lane_type == LaneType::Sidewalk)
+        .next()
+        .unwrap()
+        .lane_type
+        == LaneType::Biking
+    {
+        tags.insert("cycleway:left".to_owned(), "lane".to_string());
+    }
+    Ok(Tags(tags))
+}

--- a/rust/osm2lanes/src/transform.rs
+++ b/rust/osm2lanes/src/transform.rs
@@ -504,7 +504,7 @@ pub fn lanes_to_tags(lanes: &[LaneSpec], _cfg: &Config) -> Result<Tags, LaneSpec
         tags.insert("oneway".to_owned(), "yes".to_owned());
     }
     if lanes.first().unwrap().lane_type == LaneType::Sidewalk
-        && lanes.first().unwrap().lane_type == LaneType::Sidewalk
+        && lanes.last().unwrap().lane_type == LaneType::Sidewalk
     {
         tags.insert("sidewalk".to_owned(), "both".to_string());
     }


### PR DESCRIPTION
Prepare the boilerplate for lanes2osm.

We roundtrip lanes->osm->lanes, and not the other way around, because we expect osm to lanes to be a many to one mapping.