### PR TITLE
Add simple tests; fixes for `busway:*=lane`

### DIFF
--- a/data/tests.json
+++ b/data/tests.json
@@ -729,5 +729,31 @@
                 "direction": "forward"
             }
         ]
+    },
+    {
+        "skip_rust": true,
+        "description": "test for `busway:left=lane` and `busway:right=lane`",
+        "tags": {
+            "busway:right": "lane",
+            "busway:left": "lane",
+            "highway": "secondary",
+            "lanes": "3",
+            "oneway": "yes"
+        },
+        "driving_side": "right",
+        "output": [
+            {
+                "type": "bus_lane",
+                "direction": "backward"
+            },
+            {
+                "type": "travel_lane",
+                "direction": "forward"
+            },
+            {
+                "type": "bus_lane",
+                "direction": "forward"
+            }
+        ]
     }
 ]

--- a/data/tests.json
+++ b/data/tests.json
@@ -732,6 +732,27 @@
     },
     {
         "skip_rust": true,
+        "description": "test for `busway:left=lane`",
+        "tags": {
+            "busway:left": "lane",
+            "highway": "secondary",
+            "lanes": "2",
+            "oneway": "yes"
+        },
+        "driving_side": "right",
+        "output": [
+            {
+                "type": "bus_lane",
+                "direction": "backward"
+            },
+            {
+                "type": "travel_lane",
+                "direction": "forward"
+            }
+        ]
+    },
+    {
+        "skip_rust": true,
         "description": "test for `busway:left=lane` and `busway:right=lane`",
         "tags": {
             "busway:right": "lane",

--- a/kotlin/src/main/kotlin/Main.kt
+++ b/kotlin/src/main/kotlin/Main.kt
@@ -207,6 +207,8 @@ data class LaneUsage(
  */
 class Road(private val tags: Map<String, String>, private val drivingSide: DrivingSide) {
 
+    private val sides = setOf("left", "right")
+
     /**
      * Compute lane direction based on road side and bidirectional traffic practice.
      *
@@ -255,8 +257,9 @@ class Road(private val tags: Map<String, String>, private val drivingSide: Drivi
 
         if (tags["busway"] == "lane" || tags["busway:both"] == "lane")
             laneCount += 2
-        if (tags["busway:right"] == "lane" || tags["busway:left"] == "lane")
-            laneCount += 1
+        for (side in sides)
+            if (tags["busway:$side"] == "lane")
+                laneCount += 1
 
         return laneCount
     }
@@ -301,7 +304,6 @@ class Road(private val tags: Map<String, String>, private val drivingSide: Drivi
      */
     fun parse(): List<Lane> {
 
-        val sides = setOf("left", "right")
         val parkingValues = setOf("parallel", "diagonal")
         val trackValues = setOf("track", "opposite_track")
 

--- a/python/osm2lanes/core.py
+++ b/python/osm2lanes/core.py
@@ -7,6 +7,8 @@ from enum import Enum
 
 Tags = dict[str, str]
 
+SIDES: set[str] = {"left", "right"}
+
 
 class DrivingSide(Enum):
     """Bidirectional traffic practice."""
@@ -184,11 +186,9 @@ class Road:
         ):
             lane_count += 2
 
-        if (
-            self.tags.get("busway:right") == "lane"
-            or self.tags.get("busway:left") == "lane"
-        ):
-            lane_count += 1
+        for side in SIDES:
+            if self.tags.get(f"busway:{side}") == "lane":
+                lane_count += 1
 
         return lane_count
 
@@ -199,7 +199,6 @@ class Road:
 
         :return: list of lane specifications
         """
-        sides: set[str] = {"left", "right"}
         parking_values: set[str] = {"parallel", "diagonal"}
         track_values: set[str] = {"track", "opposite_track"}
 
@@ -246,7 +245,7 @@ class Road:
 
         lane: Lane
 
-        for side in sides:
+        for side in SIDES:
             if self.tags.get(f"cycleway:{side}") == "lane":
                 lane = Lane(
                     LaneType.CYCLEWAY,
@@ -264,7 +263,8 @@ class Road:
             or self.tags.get("busway:both") == "lane"
         ):
             lanes = self.add_both_lanes(lanes, LaneType.BUS_LANE)
-        for side in sides:
+
+        for side in SIDES:
             if self.tags.get(f"busway:{side}") == "lane":
                 lane = Lane(LaneType.BUS_LANE, self.get_direction(side))
                 lanes = self.add_lane(lanes, lane, side)
@@ -274,7 +274,7 @@ class Road:
         if self.tags.get("parking:lane:both") == "parallel":
             lanes = self.add_both_lanes(lanes, LaneType.PARKING_LANE)
 
-        for side in sides:
+        for side in SIDES:
             if self.tags.get(f"parking:lane:{side}") in parking_values:
                 lane = Lane(LaneType.PARKING_LANE, self.get_direction(side))
                 lanes = self.add_lane(lanes, lane, side)
@@ -286,7 +286,7 @@ class Road:
         elif self.tags.get("sidewalk") == "none":
             lanes = self.add_both_lanes(lanes, LaneType.SHOULDER)
         else:
-            for side in sides:
+            for side in SIDES:
                 if self.tags.get("sidewalk") == side:
                     lane = Lane(LaneType.SIDEWALK, Direction.BOTH)
                     lanes = self.add_lane(lanes, lane, side)

--- a/python/tests/test_lanes.py
+++ b/python/tests/test_lanes.py
@@ -37,7 +37,7 @@ class Case:
         """Parse test from configuration."""
         return cls(
             structure["skip_python"] if "skip_python" in structure else False,
-            structure["way_id"],
+            structure["way_id"] if "way_id" in structure else 0,
             structure["tags"],
             DrivingSide(structure["driving_side"]),
             list(map(Lane.from_structure, structure["output"])),


### PR DESCRIPTION
I want to add more simple test (that aren't based on real OSM ways). Hope this will simplify debugging.