### PR TITLE
Rust: Fix Broken Testing

### DIFF
--- a/.githooks/check
+++ b/.githooks/check
@@ -14,7 +14,7 @@ pytest || { echo "FAIL"; exit 1; }
 cd rust
 cargo test || { echo "FAIL"; exit 1; }
 cargo fmt --check || { echo "FAIL"; exit 1; }
-cargo clippy || { echo "FAIL"; exit 1; }
+cargo clippy --no-deps -- -D warnings || { echo "FAIL"; exit 1; }
 cargo +stable test || { echo "FAIL"; exit 1; }
 cd ..
 

--- a/data/tests.yml
+++ b/data/tests.yml
@@ -459,6 +459,8 @@
 - description: cycleway:BACKWARD=lane oneway=yes, cycleway is in the forward direction
   way_id: 428294122
   mapillary: https://www.mapillary.com/app/?pKey=503446704131825
+  rust:
+    ignore_warnings: true
   # https://wiki.openstreetmap.org/wiki/Key:cycleway:right:oneway
   # TODO: OSM tags do not accurately reflect parking situation
   tags:
@@ -680,6 +682,8 @@
 - way_id: 988980354
   description: busway=* and lanes:bus=*
   driving_side: right
+  rust:
+    ignore_warnings: true
   tags:
     highway: primary
     busway: lane

--- a/rust/osm2lanes/src/lib.rs
+++ b/rust/osm2lanes/src/lib.rs
@@ -19,3 +19,5 @@ pub mod overpass;
 
 pub mod transform;
 pub use self::transform::{lanes_to_tags, tags_to_lanes, LanesToTagsConfig, TagsToLanesConfig};
+
+mod test;

--- a/rust/osm2lanes/src/tags.rs
+++ b/rust/osm2lanes/src/tags.rs
@@ -215,7 +215,7 @@ impl TagTreeVal {
     }
     /// Get tree
     pub fn tree(&self) -> Option<&TagTree> {
-        Some(self.tree.as_ref()?)
+        self.tree.as_ref()
     }
 }
 

--- a/rust/osm2lanes/src/tags.rs
+++ b/rust/osm2lanes/src/tags.rs
@@ -205,11 +205,17 @@ impl TagTreeVal {
         }
         self.val = Some(input);
     }
+    /// Get nested value from tree given key
     pub fn get<K: Into<TagKey>>(&self, key: K) -> Option<&TagTreeVal> {
         self.tree.as_ref()?.get(key)
     }
+    /// Get value of root
     pub fn val(&self) -> Option<&str> {
         Some(self.val.as_ref()?.as_str())
+    }
+    /// Get tree
+    pub fn tree(&self) -> Option<&TagTree> {
+        Some(self.tree.as_ref()?)
     }
 }
 

--- a/rust/osm2lanes/src/test.rs
+++ b/rust/osm2lanes/src/test.rs
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         let tests: Vec<TestCase> =
-            serde_yaml::from_reader(BufReader::new(File::open("../../data/tests.json").unwrap()))
+            serde_yaml::from_reader(BufReader::new(File::open("../../data/tests.yml").unwrap()))
                 .unwrap();
         let tests: Vec<TestCase> = tests.into_iter().filter(|test| test.is_enabled()).collect();
 

--- a/rust/osm2lanes/src/test.rs
+++ b/rust/osm2lanes/src/test.rs
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         let tests: Vec<TestCase> =
-            serde_json::from_reader(BufReader::new(File::open("../../data/tests.json").unwrap()))
+            serde_yaml::from_reader(BufReader::new(File::open("../../data/tests.json").unwrap()))
                 .unwrap();
         let tests: Vec<TestCase> = tests.into_iter().filter(|test| test.is_enabled()).collect();
 

--- a/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
@@ -208,7 +208,10 @@ pub fn unsupported(tags: &Tags, _locale: &Locale, warnings: &mut RoadWarnings) -
     }
 
     let tag_tree = tags.tree();
-    if tag_tree.get("lanes").is_some() {
+    if tag_tree
+        .get("lanes")
+        .map_or(false, |val| val.tree().is_some())
+    {
         warnings.push(RoadMsg::Unimplemented {
             description: Some("lanes=*".to_owned()),
             // TODO, TagTree should support subset


### PR DESCRIPTION
Re-enable testing, accidentally broken during a refactor
Allow ignoring warnings.
Loosen the warnings generated by lanes:* -> This should fix the website...