### PR TITLE
Rust: Refactor Tags, Part 1?

### DIFF
--- a/rust/osm2lanes/src/tag/key.rs
+++ b/rust/osm2lanes/src/tag/key.rs
@@ -7,19 +7,22 @@
 /// assert_eq!((example_key + "foo").as_str(), "example:foo");
 /// ```
 #[derive(Clone)]
-pub enum TagKey {
+pub struct TagKey(TagKeyEnum);
+
+#[derive(Clone)]
+enum TagKeyEnum {
     Static(&'static str),
     String(String),
 }
 
 impl TagKey {
     pub const fn from(string: &'static str) -> Self {
-        TagKey::Static(string)
+        TagKey(TagKeyEnum::Static(string))
     }
     pub fn as_str(&self) -> &str {
-        match self {
-            Self::Static(v) => v,
-            Self::String(v) => v.as_str(),
+        match &self.0 {
+            TagKeyEnum::Static(v) => v,
+            TagKeyEnum::String(v) => v.as_str(),
         }
     }
 }
@@ -30,11 +33,17 @@ impl From<&'static str> for TagKey {
     }
 }
 
+impl From<String> for TagKey {
+    fn from(string: String) -> Self {
+        TagKey(TagKeyEnum::String(string))
+    }
+}
+
 impl std::ops::Add for TagKey {
     type Output = Self;
     fn add(self, other: Self) -> Self {
         let val = format!("{}:{}", self.as_str(), other.as_str());
-        TagKey::String(val)
+        val.into()
     }
 }
 

--- a/rust/osm2lanes/src/test.rs
+++ b/rust/osm2lanes/src/test.rs
@@ -341,7 +341,7 @@ mod tests {
                     println!("    {}", stringify_lane_types(&input_road));
                     println!("    {}", stringify_directions(&input_road));
                     println!("Normalized OSM tags:");
-                    for (k, v) in tags.map() {
+                    for [k, v] in tags.to_str_pairs() {
                         println!("    {} = {}", k, v);
                     }
                     println!("Got:");

--- a/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use crate::road::{Lane, LaneDesignated, LaneDirection, Marking, MarkingColor, MarkingStyle};
-use crate::tag::{TagKey, Tags, TagsRead};
+use crate::tag::{TagKey, Tags};
 use crate::{DrivingSide, Locale};
 
 mod bicycle;


### PR DESCRIPTION
Make TagKey enum private, to allow for future changes in implementation
Remove TagRead trait, as unecessary.
Remove public interfaces that used BTreeMap.