### PR TITLE
Rust: Lane Width

### DIFF
--- a/rust/osm2lanes-web/src/draw.rs
+++ b/rust/osm2lanes-web/src/draw.rs
@@ -59,8 +59,9 @@ pub fn lanes<R: RenderContext>(
             Lane::Travel {
                 direction,
                 designated,
+                width,
             } => {
-                let width = locale.default_width(designated);
+                let width = width.unwrap_or_else(|| locale.travel_width(designated));
                 let x = scale.scale(left_edge + (0.5 * width));
                 if let Some(direction) = direction {
                     draw_arrow(
@@ -101,8 +102,8 @@ pub fn lanes<R: RenderContext>(
                 rc.draw_text(&layout, (x - (0.5 * font_size), 0.5 * canvas_height));
                 left_edge += width;
             }
-            Lane::Shoulder => {
-                let width = default_lane_width;
+            Lane::Shoulder { width } => {
+                let width = width.unwrap_or(default_lane_width);
                 let x = scale.scale(left_edge + (0.5 * width));
                 let font_size = 24.0;
                 let layout = rc

--- a/rust/osm2lanes/src/locale.rs
+++ b/rust/osm2lanes/src/locale.rs
@@ -16,7 +16,7 @@ impl Locale {
     pub fn builder() -> Config {
         Config::default()
     }
-    pub fn default_width(&self, designated: &LaneDesignated) -> Metre {
+    pub const fn travel_width(&self, designated: &LaneDesignated) -> Metre {
         match designated {
             LaneDesignated::Motor | LaneDesignated::Bus => Metre::new(3.5),
             LaneDesignated::Foot => Metre::new(2.5),

--- a/rust/osm2lanes/src/locale.rs
+++ b/rust/osm2lanes/src/locale.rs
@@ -20,7 +20,7 @@ impl Locale {
     pub fn builder() -> Config {
         Config::default()
     }
-    pub const fn travel_width(&self, designated: &LaneDesignated) -> Metre {
+    pub fn travel_width(&self, designated: &LaneDesignated) -> Metre {
         match designated {
             LaneDesignated::Motor | LaneDesignated::Bus => Metre::new(3.5),
             LaneDesignated::Foot => Metre::new(2.5),

--- a/rust/osm2lanes/src/test.rs
+++ b/rust/osm2lanes/src/test.rs
@@ -54,14 +54,56 @@ mod tests {
     impl Lane {
         /// Eq where None is treaty as always equal
         fn approx_eq(&self, other: &Self) -> bool {
-            if let (Lane::Separator { markings: left }, Lane::Separator { markings: right }) =
-                (self, other)
-            {
-                left.iter()
+            match (self, other) {
+                (Lane::Separator { markings: left }, Lane::Separator { markings: right }) => left
+                    .iter()
                     .zip(right.iter())
-                    .all(|(left, right)| left.approx_eq(right))
-            } else {
-                self == other
+                    .all(|(left, right)| left.approx_eq(right)),
+                (
+                    Lane::Travel {
+                        designated: left_designated,
+                        direction: left_direction,
+                        width: left_width,
+                    },
+                    Lane::Travel {
+                        designated: right_designated,
+                        direction: right_direction,
+                        width: right_width,
+                    },
+                ) => {
+                    left_designated == right_designated
+                        && left_direction == right_direction
+                        && match (left_width, right_width) {
+                            (None, None) | (Some(_), None) | (None, Some(_)) => true,
+                            (Some(left), Some(right)) => left == right,
+                        }
+                }
+                (
+                    Lane::Parking {
+                        designated: left_designated,
+                        direction: left_direction,
+                        width: left_width,
+                    },
+                    Lane::Parking {
+                        designated: right_designated,
+                        direction: right_direction,
+                        width: right_width,
+                    },
+                ) => {
+                    left_designated == right_designated
+                        && left_direction == right_direction
+                        && match (left_width, right_width) {
+                            (None, None) | (Some(_), None) | (None, Some(_)) => true,
+                            (Some(left), Some(right)) => left == right,
+                        }
+                }
+                (Lane::Shoulder { width: left_width }, Lane::Shoulder { width: right_width }) => {
+                    match (left_width, right_width) {
+                        (None, None) | (Some(_), None) | (None, Some(_)) => true,
+                        (Some(left), Some(right)) => left == right,
+                    }
+                }
+                (left, right) => left == right,
             }
         }
     }

--- a/rust/osm2lanes/src/transform/lanes_to_tags.rs
+++ b/rust/osm2lanes/src/transform/lanes_to_tags.rs
@@ -56,8 +56,8 @@ pub fn lanes_to_tags(lanes: &[Lane], locale: &Locale, config: &LanesToTagsConfig
     }
     // Shoulder
     match (
-        lanes.first().unwrap() == &Lane::Shoulder,
-        lanes.last().unwrap() == &Lane::Shoulder,
+        lanes.first().unwrap().is_shoulder(),
+        lanes.last().unwrap().is_shoulder(),
     ) {
         (false, false) => {
             // TODO do we want to always be explicit about this?
@@ -182,6 +182,7 @@ pub fn lanes_to_tags(lanes: &[Lane], locale: &Locale, config: &LanesToTagsConfig
             Lane::Travel {
                 designated: LaneDesignated::Motor,
                 direction: Some(LaneDirection::Both),
+                ..
             }
         )
     }) {

--- a/rust/osm2lanes/src/transform/tags_to_lanes/bicycle.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/bicycle.rs
@@ -11,25 +11,28 @@ impl Tags {
 }
 
 impl LaneBuilder {
-    fn cycle_forward(locale: &Locale) -> Self {
+    fn cycle_forward(_locale: &Locale) -> Self {
         Self {
             r#type: Infer::Direct(LaneType::Travel),
             direction: Infer::Direct(LaneDirection::Forward),
             designated: Infer::Direct(LaneDesignated::Bicycle),
+            ..Default::default()
         }
     }
-    fn cycle_backward(locale: &Locale) -> Self {
+    fn cycle_backward(_locale: &Locale) -> Self {
         Self {
             r#type: Infer::Direct(LaneType::Travel),
             direction: Infer::Direct(LaneDirection::Backward),
             designated: Infer::Direct(LaneDesignated::Bicycle),
+            ..Default::default()
         }
     }
-    fn cycle_both(locale: &Locale) -> Self {
+    fn cycle_both(_locale: &Locale) -> Self {
         Self {
             r#type: Infer::Direct(LaneType::Travel),
             direction: Infer::Direct(LaneDirection::Both),
             designated: Infer::Direct(LaneDesignated::Bicycle),
+            ..Default::default()
         }
     }
 }

--- a/rust/osm2lanes/src/transform/tags_to_lanes/bicycle.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/bicycle.rs
@@ -25,7 +25,7 @@ pub fn bicycle(
         {
             return Err(RoadMsg::unsupported_str("cycleway=* with any cycleway:* values").into());
         }
-        forward_side.push(Lane::forward(LaneDesignated::Bicycle));
+        forward_side.push(Lane::forward(LaneDesignated::Bicycle, locale));
         if oneway {
             if !backward_side.is_empty() {
                 // TODO safety check to be checked
@@ -37,11 +37,11 @@ pub fn bicycle(
                 })
             }
         } else {
-            backward_side.push(Lane::backward(LaneDesignated::Bicycle));
+            backward_side.push(Lane::backward(LaneDesignated::Bicycle, locale));
         }
     } else if tags.is_cycleway(Some(WaySide::Both)) {
-        forward_side.push(Lane::forward(LaneDesignated::Bicycle));
-        backward_side.push(Lane::backward(LaneDesignated::Bicycle));
+        forward_side.push(Lane::forward(LaneDesignated::Bicycle, locale));
+        backward_side.push(Lane::backward(LaneDesignated::Bicycle, locale));
     } else {
         // cycleway=opposite_lane
         if tags.is(CYCLEWAY, "opposite_lane") {
@@ -49,7 +49,7 @@ pub fn bicycle(
                 deprecated_tags: tags.subset(&["cycleway", "oneway"]),
                 suggested_tags: None,
             });
-            backward_side.push(Lane::backward(LaneDesignated::Bicycle));
+            backward_side.push(Lane::backward(LaneDesignated::Bicycle, locale));
         }
         // cycleway=opposite oneway=yes oneway:bicycle=no
         if tags.is(CYCLEWAY, "opposite") {
@@ -59,16 +59,16 @@ pub fn bicycle(
                 )
                 .into());
             }
-            backward_side.push(Lane::backward(LaneDesignated::Bicycle));
+            backward_side.push(Lane::backward(LaneDesignated::Bicycle, locale));
         }
         // cycleway:FORWARD=*
         if tags.is_cycleway(Some(locale.driving_side.into())) {
             if tags.is(CYCLEWAY + locale.driving_side.tag() + "oneway", "no")
                 || tags.is("oneway:bicycle", "no")
             {
-                forward_side.push(Lane::both(LaneDesignated::Bicycle));
+                forward_side.push(Lane::both(LaneDesignated::Bicycle, locale));
             } else {
-                forward_side.push(Lane::forward(LaneDesignated::Bicycle));
+                forward_side.push(Lane::forward(LaneDesignated::Bicycle, locale));
             }
         }
         // cycleway:FORWARD=opposite_lane
@@ -80,7 +80,7 @@ pub fn bicycle(
                 deprecated_tags: tags.subset(&[CYCLEWAY + locale.driving_side.tag()]),
                 suggested_tags: None,
             });
-            forward_side.push(Lane::backward(LaneDesignated::Bicycle));
+            forward_side.push(Lane::backward(LaneDesignated::Bicycle, locale));
         }
         // cycleway:BACKWARD=*
         if tags.is_cycleway(Some(locale.driving_side.opposite().into())) {
@@ -88,24 +88,24 @@ pub fn bicycle(
                 CYCLEWAY + locale.driving_side.opposite().tag() + "oneway",
                 "yes",
             ) {
-                forward_side.insert(0, Lane::forward(LaneDesignated::Bicycle));
+                forward_side.insert(0, Lane::forward(LaneDesignated::Bicycle, locale));
             } else if tags.is(
                 CYCLEWAY + locale.driving_side.opposite().tag() + "oneway",
                 "-1",
             ) {
-                backward_side.push(Lane::backward(LaneDesignated::Bicycle));
+                backward_side.push(Lane::backward(LaneDesignated::Bicycle, locale));
             } else if tags.is(
                 CYCLEWAY + locale.driving_side.opposite().tag() + "oneway",
                 "no",
             ) || tags.is("oneway:bicycle", "no")
             {
-                backward_side.push(Lane::both(LaneDesignated::Bicycle));
+                backward_side.push(Lane::both(LaneDesignated::Bicycle, locale));
             } else if oneway {
                 // A oneway road with a cycleway on the wrong side
-                forward_side.insert(0, Lane::forward(LaneDesignated::Bicycle));
+                forward_side.insert(0, Lane::forward(LaneDesignated::Bicycle, locale));
             } else {
                 // A contraflow bicycle lane
-                backward_side.push(Lane::backward(LaneDesignated::Bicycle));
+                backward_side.push(Lane::backward(LaneDesignated::Bicycle, locale));
             }
         }
         // cycleway:BACKWARD=opposite_lane

--- a/rust/osm2lanes/src/transform/tags_to_lanes/bus.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/bus.rs
@@ -140,7 +140,7 @@ fn lanes_bus(
 
 fn bus_lanes(
     tags: &Tags,
-    _locale: &Locale,
+    locale: &Locale,
     oneway: bool,
     forward_side: &mut [Lane],
     backward_side: &mut [Lane],
@@ -181,9 +181,11 @@ fn bus_lanes(
                         } else {
                             unreachable!()
                         };
+                    let designated = LaneDesignated::Bus;
                     forward_side[idx + offset] = Lane::Travel {
                         direction,
-                        designated: LaneDesignated::Bus,
+                        designated,
+                        width: Some(locale.travel_width(&designated)),
                     };
                 }
             }
@@ -202,9 +204,11 @@ fn bus_lanes(
                     } else {
                         unreachable!()
                     };
+                    let designated = LaneDesignated::Bus;
                     backward_side[idx] = Lane::Travel {
                         direction,
-                        designated: LaneDesignated::Bus,
+                        designated,
+                        width: Some(locale.travel_width(&designated)),
                     };
                 }
             }

--- a/rust/osm2lanes/src/transform/tags_to_lanes/bus.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/bus.rs
@@ -9,7 +9,7 @@ impl RoadError {
 }
 
 impl LaneBuilder {
-    fn set_bus(&mut self, locale: &Locale) -> Result<(), LaneBuilderError> {
+    fn set_bus(&mut self, _locale: &Locale) -> Result<(), LaneBuilderError> {
         self.designated = Infer::Direct(LaneDesignated::Bus);
         Ok(())
     }

--- a/rust/osm2lanes/src/transform/tags_to_lanes/foot_shoulder.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/foot_shoulder.rs
@@ -1,13 +1,13 @@
 use super::*;
 
 impl LaneBuilder {
-    fn shoulder(locale: &Locale) -> Self {
+    fn shoulder(_locale: &Locale) -> Self {
         Self {
             r#type: Infer::Direct(LaneType::Shoulder),
             ..Default::default()
         }
     }
-    fn foot(locale: &Locale) -> Self {
+    fn foot(_locale: &Locale) -> Self {
         Self {
             r#type: Infer::Direct(LaneType::Travel),
             designated: Infer::Direct(LaneDesignated::Foot),

--- a/rust/osm2lanes/src/transform/tags_to_lanes/foot_shoulder.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/foot_shoulder.rs
@@ -116,12 +116,12 @@ pub fn foot_and_shoulder(
                 let has_bicycle_lane = side.last().map_or(false, |lane| lane.is_bicycle());
 
                 if !has_bicycle_lane && (forward || !oneway) {
-                    side.push(Lane::Shoulder)
+                    side.push(Lane::shoulder(locale))
                 }
             }
             (Sidewalk::No | Sidewalk::None, Shoulder::No) => {}
-            (Sidewalk::Yes, Shoulder::No | Shoulder::None) => side.push(Lane::foot()),
-            (Sidewalk::No | Sidewalk::None, Shoulder::Yes) => side.push(Lane::Shoulder),
+            (Sidewalk::Yes, Shoulder::No | Shoulder::None) => side.push(Lane::foot(locale)),
+            (Sidewalk::No | Sidewalk::None, Shoulder::Yes) => side.push(Lane::shoulder(locale)),
             (Sidewalk::Yes, Shoulder::Yes) => {
                 return Err(RoadMsg::Unsupported {
                     description: Some("shoulder and sidewalk on same side".to_owned()),

--- a/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
@@ -72,15 +72,15 @@ pub fn tags_to_lanes(tags: &Tags, locale: &Locale, config: &TagsToLanesConfig) -
 
     // These are ordered from the road center, going outwards. Most of the members of fwd_side will
     // have Direction::Forward, but there can be exceptions with two-way cycletracks.
-    let mut fwd_side: Vec<Lane> = iter::repeat_with(|| Lane::forward(driving_lane))
+    let mut fwd_side: Vec<Lane> = iter::repeat_with(|| Lane::forward(driving_lane, locale))
         .take(num_driving_fwd)
         .collect();
-    let mut back_side: Vec<Lane> = iter::repeat_with(|| Lane::backward(driving_lane))
+    let mut back_side: Vec<Lane> = iter::repeat_with(|| Lane::backward(driving_lane, locale))
         .take(num_driving_back)
         .collect();
     // TODO Fix upstream. https://wiki.openstreetmap.org/wiki/Key:centre_turn_lane
     if tags.is("lanes:both_ways", "1") || tags.is("centre_turn_lane", "yes") {
-        fwd_side.insert(0, Lane::both(LaneDesignated::Motor));
+        fwd_side.insert(0, Lane::both(LaneDesignated::Motor, locale));
     }
 
     bus(

--- a/rust/osm2lanes/src/transform/tags_to_lanes/non_motorized.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/non_motorized.rs
@@ -18,7 +18,7 @@ pub fn non_motorized(tags: &Tags, locale: &Locale) -> Result<Option<Lanes>, Road
     // Easy special cases first.
     if tags.is(HIGHWAY, "steps") {
         return Ok(Some(Lanes {
-            lanes: vec![Lane::foot()],
+            lanes: vec![Lane::foot(locale)],
             warnings: RoadWarnings::new(vec![RoadMsg::Other {
                 description: "highway is steps, but lane is only a sidewalk".to_owned(),
                 tags: tags.subset(&[HIGHWAY]),
@@ -36,23 +36,23 @@ pub fn non_motorized(tags: &Tags, locale: &Locale) -> Result<Option<Lanes>, Road
         || (tags.is(HIGHWAY, "footway") && !tags.is_any("bicycle", &["designated", "yes"]))
     {
         return Ok(Some(Lanes {
-            lanes: vec![Lane::foot()],
+            lanes: vec![Lane::foot(locale)],
             warnings: RoadWarnings::default(),
         }));
     }
     // Otherwise, there'll always be a bike lane.
 
-    let mut forward_side = vec![Lane::forward(LaneDesignated::Bicycle)];
+    let mut forward_side = vec![Lane::forward(LaneDesignated::Bicycle, locale)];
     let mut backward_side = if tags.is("oneway", "yes") {
         vec![]
     } else {
-        vec![Lane::backward(LaneDesignated::Bicycle)]
+        vec![Lane::backward(LaneDesignated::Bicycle, locale)]
     };
 
     if !tags.is("foot", "no") {
-        forward_side.push(Lane::Shoulder);
+        forward_side.push(Lane::shoulder(locale));
         if !backward_side.is_empty() {
-            backward_side.push(Lane::Shoulder);
+            backward_side.push(Lane::shoulder(locale));
         }
     }
     Ok(Some(Lanes {

--- a/rust/osm2lanes/src/transform/tags_to_lanes/parking.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/parking.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn parking(
     tags: &Tags,
-    _locale: &Locale,
+    locale: &Locale,
     _oneway: bool,
     forward_side: &mut Vec<Lane>,
     backward_side: &mut Vec<Lane>,
@@ -13,9 +13,9 @@ pub fn parking(
     let parking_lane_back = tags.is_any("parking:lane:left", &has_parking)
         || tags.is_any("parking:lane:both", &has_parking);
     if parking_lane_fwd {
-        forward_side.push(Lane::parking(LaneDirection::Forward));
+        forward_side.push(Lane::parking(LaneDirection::Forward, locale));
     }
     if parking_lane_back {
-        backward_side.push(Lane::parking(LaneDirection::Backward));
+        backward_side.push(Lane::parking(LaneDirection::Backward, locale));
     }
 }

--- a/rust/osm2lanes/src/transform/tags_to_lanes/parking.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/parking.rs
@@ -1,18 +1,20 @@
 use super::*;
 
 impl LaneBuilder {
-    fn parking_forward(locale: &Locale) -> Self {
+    fn parking_forward(_locale: &Locale) -> Self {
         Self {
             r#type: Infer::Direct(LaneType::Parking),
             direction: Infer::Direct(LaneDirection::Forward),
             designated: Infer::Direct(LaneDesignated::Motor),
+            ..Default::default()
         }
     }
-    fn parking_backward(locale: &Locale) -> Self {
+    fn parking_backward(_locale: &Locale) -> Self {
         Self {
             r#type: Infer::Direct(LaneType::Parking),
             direction: Infer::Direct(LaneDirection::Backward),
             designated: Infer::Direct(LaneDesignated::Motor),
+            ..Default::default()
         }
     }
 }

--- a/rust/osm2lanes/src/transform/tags_to_lanes/separator.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/separator.rs
@@ -47,7 +47,7 @@ fn lanes_to_separator(lanes: &[Lane; 2], road: &[Lane]) -> Option<Lane> {
                 width: Some(Marking::DEFAULT_WIDTH),
             }]),
         }),
-        [Lane::Shoulder, _] | [_, Lane::Shoulder] => Some(Lane::Separator {
+        [Lane::Shoulder { .. }, _] | [_, Lane::Shoulder { .. }] => Some(Lane::Separator {
             markings: Markings::new(vec![Marking {
                 style: MarkingStyle::SolidLine,
                 color: Some(MarkingColor::White),


### PR DESCRIPTION
Add lane width to rust lane structs.
Locale now does the heavy lifting with travel_width.