### PR TITLE
Rust Website: Add Country Support

### DIFF
--- a/rust/osm2lanes-web/Cargo.toml
+++ b/rust/osm2lanes-web/Cargo.toml
@@ -17,7 +17,7 @@ yew = "0.19"
 
 [dependencies.web-sys]
 version = "0.3"
-features = ["HtmlInputElement", "HtmlCanvasElement"]
+features = ["HtmlInputElement", "HtmlCanvasElement", "HtmlSelectElement"]
 
 [features]
 default = ["console_log", "wee_alloc"]

--- a/rust/osm2lanes-web/assets/css/main.css
+++ b/rust/osm2lanes-web/assets/css/main.css
@@ -1,4 +1,4 @@
-body, h1, h2, h3, h4, h5, a, button, input, textarea, .button, label, p {
+body, h1, h2, h3, h4, h5, a, button, input, textarea, .button, label, p, select {
   font-family: "Source Code Pro", monospace;
   margin: 1ex 0.5em;
   padding: 0.5ex 0em;

--- a/rust/osm2lanes/Cargo.toml
+++ b/rust/osm2lanes/Cargo.toml
@@ -6,9 +6,10 @@ authors = ["Dustin Carlino <dabreegster@gmail.com>", "Michael Droogleever Fortuy
 license = "Apache 2.0"
 
 [dependencies]
+celes = "2.1"
 log = "0.4"
-serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
+serde = { version = "1", features = ["derive"] }
 
 [features]
 overpass = ["reqwest", "reqwest/blocking", "reqwest/json"]

--- a/rust/osm2lanes/src/lib.rs
+++ b/rust/osm2lanes/src/lib.rs
@@ -11,13 +11,13 @@ pub mod road;
 
 pub mod tag;
 
-mod locale;
-pub use self::locale::{DrivingSide, Locale};
+pub mod locale;
+pub use locale::{DrivingSide, Locale};
 
 #[cfg(feature = "overpass")]
 pub mod overpass;
 
 pub mod transform;
-pub use self::transform::{lanes_to_tags, tags_to_lanes, LanesToTagsConfig, TagsToLanesConfig};
+pub use transform::{lanes_to_tags, tags_to_lanes, LanesToTagsConfig, TagsToLanesConfig};
 
 mod test;

--- a/rust/osm2lanes/src/locale.rs
+++ b/rust/osm2lanes/src/locale.rs
@@ -1,3 +1,4 @@
+pub use celes::Country;
 use serde::{Deserialize, Serialize};
 
 use crate::road::LaneDesignated;
@@ -6,6 +7,9 @@ use crate::Metre;
 /// Context about the place where an OSM way exists.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Locale {
+    /// The ISO 3166 Country
+    pub country: Option<Country>,
+    /// The driving side
     pub driving_side: DrivingSide,
     /// When sidewalks are not explicitly tagged on a way,
     /// sidewalks may be inferred
@@ -63,6 +67,7 @@ impl Config {
     pub fn build(&self) -> Locale {
         // TODO, more business logic
         Locale {
+            country: None,
             driving_side: self.driving_side.unwrap_or(DrivingSide::Right),
             infer_sidewalks: self.infer_sidewalks.unwrap_or(true), // TODO?
         }


### PR DESCRIPTION
Uses celec dependency for ISO 3166 country definitions.

The default selected country should maybe be set initially, but for now is not.