### PR TITLE
Start a demo of clicking a road and plugging it into osm2lanes

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Mapbox GL + osm2lanes</title>
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <link
+      href="https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.css"
+      rel="stylesheet"
+    />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.js"></script>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      #map {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.7.2/mapbox-gl-geocoder.min.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.7.2/mapbox-gl-geocoder.css"
+      type="text/css"
+    />
+
+    <div id="map"></div>
+
+    <script>
+      mapboxgl.accessToken =
+        "pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw";
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: "mapbox://styles/mapbox/streets-v11",
+        center: [-0.1207, 51.5111],
+        zoom: 13,
+      });
+
+      map.addControl(
+        new MapboxGeocoder({
+          accessToken: mapboxgl.accessToken,
+          mapboxgl: mapboxgl,
+          flyTo: {
+            maxDuration: 100,
+          },
+          marker: false,
+        })
+      );
+    </script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -69,6 +69,25 @@
         })
       );
 
+      map.on("load", function () {
+        map.addSource("road", {
+          type: "geojson",
+          data: {
+            type: "FeatureCollection",
+            features: [],
+          },
+        });
+        map.addLayer({
+          id: "road",
+          type: "line",
+          source: "road",
+          paint: {
+            "line-color": "red",
+            "line-width": 10,
+          },
+        });
+      });
+
       function queryOverpass(lngLat) {
         const maxDistMeters = 10;
         const query = `[out:json];
@@ -91,6 +110,9 @@
           null,
           2
         );
+
+        // Add the first feature to the map
+        map.getSource("road").setData(geojson["features"][0]);
       }
 
       map.on("click", (e) => {

--- a/web/index.html
+++ b/web/index.html
@@ -20,8 +20,18 @@
       #map {
         position: absolute;
         top: 0;
-        bottom: 0;
         width: 100%;
+        height: 80%;
+      }
+      #input {
+        position: absolute;
+        left: 0px;
+        bottom: 0px;
+      }
+      #output {
+        position: absolute;
+        right: 0px;
+        bottom: 0px;
       }
     </style>
   </head>
@@ -34,6 +44,8 @@
     />
 
     <div id="map"></div>
+    <textarea id="input" rows="10" cols="80" disabled>Input</textarea>
+    <textarea id="output" rows="10" cols="80" disabled>Output</textarea>
 
     <script>
       mapboxgl.accessToken =
@@ -55,6 +67,31 @@
           marker: false,
         })
       );
+
+      function queryOverpass(lngLat) {
+        const maxDistMeters = 10;
+        const query = `[out:json];
+	      way
+	      (around:${maxDistMeters},${lngLat.lat},${lngLat.lng})
+	      ["highway"];
+	      out tags;`;
+        const url = `https://overpass-api.de/api/interpreter?data=${query}`;
+        document.getElementById("input").innerText = `fetching ${url}`;
+        fetch(url)
+          .then((response) => response.json())
+          .then((json) => {
+            for (const result of json.elements) {
+              document.getElementById("input").innerText =
+                JSON.stringify(result);
+              // Only use the first
+              break;
+            }
+          });
+      }
+
+      map.on("click", (e) => {
+        queryOverpass(e.lngLat);
+      });
     </script>
   </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,7 @@
       rel="stylesheet"
     />
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/osmtogeojson@3.0.0-beta.4/osmtogeojson.js"></script>
     <style>
       body {
         margin: 0;
@@ -74,19 +75,22 @@
 	      way
 	      (around:${maxDistMeters},${lngLat.lat},${lngLat.lng})
 	      ["highway"];
-	      out tags;`;
+	      out tags geom;`;
         const url = `https://overpass-api.de/api/interpreter?data=${query}`;
         document.getElementById("input").innerText = `fetching ${url}`;
         fetch(url)
           .then((response) => response.json())
           .then((json) => {
-            for (const result of json.elements) {
-              document.getElementById("input").innerText =
-                JSON.stringify(result);
-              // Only use the first
-              break;
-            }
+            gotRoads(osmtogeojson(json));
           });
+      }
+
+      function gotRoads(geojson) {
+        document.getElementById("input").innerHTML = JSON.stringify(
+          geojson,
+          null,
+          2
+        );
       }
 
       map.on("click", (e) => {

--- a/web/serve_locally.py
+++ b/web/serve_locally.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# This serves the current directory over HTTP. We need something more than
+# `python3 -m http.server 8000` to inject the CORS header.
+
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+import sys
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    test(CORSRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)


### PR DESCRIPTION
The https://a-b-street.github.io/osm2lanes/ web interface is great, but an easier user flow is to just click a map and automatically grab the way from Overpass. This PR does the first half of that -- click a road in Mapbox, find the nearest way, display the road on the map (just as a line-string).

The second half will actually plug into osm2lanes; I'll resume #60 for that.

I'm doing this all in vanilla JS, no frameworks or anything. The goal is to make example code for other people to build off of, hopefully in time for FOSSGIS this weekend.