### PR TITLE
Rust: Fix Website Warnings

### DIFF
--- a/rust/osm2lanes/src/transform/lanes_to_tags.rs
+++ b/rust/osm2lanes/src/transform/lanes_to_tags.rs
@@ -16,6 +16,12 @@ pub struct LanesToTagsConfig {
     pub check_roundtrip: bool,
 }
 
+impl LanesToTagsConfig {
+    pub fn new(check_roundtrip: bool) -> Self {
+        LanesToTagsConfig { check_roundtrip }
+    }
+}
+
 impl Default for LanesToTagsConfig {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
https://a-b-street.github.io/osm2lanes/

the roundtrip tags are shown again

warnings are deduplicated