### PR TITLE
Rust: Add Error Locations

### DIFF
--- a/rust/osm2lanes/Cargo.toml
+++ b/rust/osm2lanes/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2021"
 celes = "2.1"
 locale-codes = "0.3"
 log = "0.4"
+thiserror = "1"
 reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = { version = "0.8", optional = true }

--- a/rust/osm2lanes/src/transform/mod.rs
+++ b/rust/osm2lanes/src/transform/mod.rs
@@ -3,13 +3,13 @@ use crate::road::{Designated, Direction, Lane};
 use crate::tag::TagKey;
 
 mod error;
-pub use error::{RoadError, RoadFromTags, RoadMsg, RoadWarnings};
+pub use error::{RoadError, RoadFromTags, RoadWarnings};
 
 mod tags_to_lanes;
-pub use tags_to_lanes::{tags_to_lanes, Config as TagsToLanesConfig};
+pub use tags_to_lanes::{tags_to_lanes, Config as TagsToLanesConfig, TagsToLanesMsg};
 
 mod lanes_to_tags;
-pub use lanes_to_tags::{lanes_to_tags, Config as LanesToTagsConfig};
+pub use lanes_to_tags::{lanes_to_tags, Config as LanesToTagsConfig, LanesToTagsMsg};
 
 pub mod tags {
     use crate::tag::TagKey;

--- a/rust/osm2lanes/src/transform/tags_to_lanes/error.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/error.rs
@@ -1,0 +1,308 @@
+use std::panic::Location;
+
+use serde::Serialize;
+
+use crate::tag::{DuplicateKeyError, TagKey, Tags};
+use crate::transform::tags_to_lanes::LaneBuilder;
+
+/// Tags to Lanes Transformation Logic Issue
+///
+/// ```
+/// use osm2lanes::transform::TagsToLanesMsg;
+/// let _ = TagsToLanesMsg::deprecated_tag("foo", "bar");
+/// let _ = TagsToLanesMsg::unsupported_tag("foo", "bar");
+/// let _ = TagsToLanesMsg::unsupported_str("foo=bar because x and y");
+/// ```
+#[derive(Clone, Debug)]
+pub struct TagsToLanesMsg {
+    location: &'static Location<'static>,
+    issue: TagsToLanesIssue,
+}
+
+#[derive(Clone, Debug)]
+pub enum TagsToLanesIssue {
+    /// Deprecated OSM tags, with suggested alternative
+    Deprecated {
+        deprecated_tags: Tags,
+        suggested_tags: Option<Tags>,
+    },
+    /// Tag combination that is unsupported, and may never be supported
+    Unsupported {
+        description: Option<String>,
+        tags: Option<Tags>,
+    },
+    /// Tag combination that is known, but has yet to be implemented
+    Unimplemented {
+        description: Option<String>,
+        tags: Option<Tags>,
+    },
+    /// Tag combination that is ambiguous, and may never be supported
+    Ambiguous {
+        description: Option<String>,
+        tags: Option<Tags>,
+    },
+    /// Locale not used
+    SeparatorLocaleUnused {
+        inside: LaneBuilder,
+        outside: LaneBuilder,
+    },
+    /// Locale not used
+    SeparatorUnknown {
+        inside: LaneBuilder,
+        outside: LaneBuilder,
+    },
+    /// Internal errors
+    TagsDuplicateKey(DuplicateKeyError),
+    Internal(&'static str),
+}
+
+impl TagsToLanesMsg {
+    #[must_use]
+    #[track_caller]
+    pub fn deprecated_tags(tags: Tags) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Deprecated {
+                deprecated_tags: tags,
+                suggested_tags: None,
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn deprecated_tag<K: Into<TagKey>>(key: K, val: &str) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Deprecated {
+                deprecated_tags: Tags::from_str_pair([key.into().as_str(), val]),
+                suggested_tags: None,
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn unsupported(description: &str, tags: Tags) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Unsupported {
+                description: Some(description.to_owned()),
+                tags: Some(tags),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn unsupported_tags(tags: Tags) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Unsupported {
+                description: None,
+                tags: Some(tags),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn unsupported_tag<K: Into<TagKey>>(key: K, val: &str) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Unsupported {
+                description: None,
+                tags: Some(Tags::from_str_pair([key.into().as_str(), val])),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn unsupported_str(description: &str) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Unsupported {
+                description: Some(description.to_owned()),
+                tags: None,
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn unimplemented(description: &str, tags: Tags) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Unimplemented {
+                description: Some(description.to_owned()),
+                tags: Some(tags),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn unimplemented_tag<K: Into<TagKey>>(key: K, val: &str) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Unimplemented {
+                description: None,
+                tags: Some(Tags::from_str_pair([key.into().as_str(), val])),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn unimplemented_tags(tags: Tags) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Unimplemented {
+                description: None,
+                tags: Some(tags),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn ambiguous_tag<K: Into<TagKey>>(key: K, val: &str) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Ambiguous {
+                description: None,
+                tags: Some(Tags::from_str_pair([key.into().as_str(), val])),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn ambiguous_tags(tags: Tags) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Ambiguous {
+                description: None,
+                tags: Some(tags),
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn ambiguous_str(description: &str) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Ambiguous {
+                description: Some(description.to_owned()),
+                tags: None,
+            },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn separator_locale_unused(inside: LaneBuilder, outside: LaneBuilder) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::SeparatorLocaleUnused { inside, outside },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn separator_unknown(inside: LaneBuilder, outside: LaneBuilder) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::SeparatorUnknown { inside, outside },
+        }
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub fn internal(e: &'static str) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::Internal(e),
+        }
+    }
+}
+
+impl std::convert::From<DuplicateKeyError> for TagsToLanesMsg {
+    #[track_caller]
+    fn from(e: DuplicateKeyError) -> Self {
+        TagsToLanesMsg {
+            location: Location::caller(),
+            issue: TagsToLanesIssue::TagsDuplicateKey(e),
+        }
+    }
+}
+
+impl std::fmt::Display for TagsToLanesMsg {
+    #[allow(clippy::panic_in_result_fn)]
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.issue {
+            TagsToLanesIssue::Deprecated {
+                deprecated_tags, ..
+            } => write!(
+                f,
+                "deprecated: '{}' - {}",
+                deprecated_tags.to_vec().as_slice().join(" "),
+                self.location,
+            ),
+            TagsToLanesIssue::Unsupported { description, tags }
+            | TagsToLanesIssue::Unimplemented { description, tags }
+            | TagsToLanesIssue::Ambiguous { description, tags } => {
+                let tags = tags.as_ref().map(|tags| tags.to_vec().as_slice().join(" "));
+                let prefix = match self.issue {
+                    TagsToLanesIssue::Unsupported { .. } => "unsupported",
+                    TagsToLanesIssue::Unimplemented { .. } => "unimplemented",
+                    TagsToLanesIssue::Ambiguous { .. } => "ambiguous",
+                    _ => unreachable!(),
+                };
+                match (description, tags) {
+                    (None, None) => write!(f, "{}", prefix),
+                    (Some(description), None) => {
+                        write!(f, "{}: '{}'", prefix, description)
+                    },
+                    (None, Some(tags)) => write!(f, "{}: '{}' - {}", prefix, tags, self.location),
+                    (Some(description), Some(tags)) => {
+                        write!(
+                            f,
+                            "{}: '{}' - '{}' - {}",
+                            prefix, description, tags, self.location
+                        )
+                    },
+                }
+            },
+            TagsToLanesIssue::SeparatorLocaleUnused { inside, outside } => {
+                write!(
+                    f,
+                    "default separator may not match locale for {:?} to {:?} - {}",
+                    inside, outside, self.location,
+                )
+            },
+            TagsToLanesIssue::SeparatorUnknown { inside, outside } => {
+                write!(
+                    f,
+                    "unknown separator for {:?} to {:?} - {}",
+                    inside, outside, self.location
+                )
+            },
+            TagsToLanesIssue::TagsDuplicateKey(e) => write!(f, "{} - {}", e, self.location),
+            TagsToLanesIssue::Internal(e) => write!(f, "{} - {}", e, self.location),
+        }
+    }
+}
+
+impl std::error::Error for TagsToLanesMsg {}
+
+impl Serialize for TagsToLanesMsg {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}

--- a/rust/osm2lanes/src/transform/tags_to_lanes/modes/non_motorized.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/modes/non_motorized.rs
@@ -1,8 +1,8 @@
 use crate::locale::{DrivingSide, Locale};
 use crate::road::{Designated, Lane, Road};
 use crate::tag::{Tags, HIGHWAY};
-use crate::transform::tags_to_lanes::RoadBuilder;
-use crate::transform::{RoadError, RoadFromTags, RoadMsg, RoadWarnings};
+use crate::transform::tags_to_lanes::{RoadBuilder, TagsToLanesMsg};
+use crate::transform::{RoadError, RoadFromTags, RoadWarnings};
 
 impl Lane {
     fn shoulder(locale: &Locale) -> Self {
@@ -42,10 +42,10 @@ pub(in crate::transform::tags_to_lanes) fn non_motorized(
                 highway: road.highway.clone(),
             },
             warnings: RoadWarnings::new(if tags.is(HIGHWAY, "steps") {
-                vec![RoadMsg::Other {
-                    description: "highway is steps, but lane is only a sidewalk".to_owned(),
-                    tags: tags.subset(&[HIGHWAY]),
-                }]
+                vec![TagsToLanesMsg::unimplemented(
+                    "steps becomes sidewalk",
+                    tags.subset(&[HIGHWAY]),
+                )]
             } else {
                 Vec::new()
             }),

--- a/rust/osm2lanes/src/transform/tags_to_lanes/separator/mod.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/separator/mod.rs
@@ -3,7 +3,7 @@ use celes::Country;
 use crate::locale::Locale;
 use crate::road::{Color, Designated, Direction, Lane, Marking, Markings, Style};
 use crate::tag::Tags;
-use crate::transform::{RoadMsg, RoadWarnings};
+use crate::transform::{RoadWarnings, TagsToLanesMsg};
 
 mod semantic;
 
@@ -77,10 +77,10 @@ pub(in crate::transform::tags_to_lanes) fn lane_pair_to_semantic_separator(
         },
         // TODO: error return
         _ => {
-            warnings.push(RoadMsg::SeparatorUnknown {
-                inside: inside.clone(),
-                outside: outside.clone(),
-            });
+            warnings.push(TagsToLanesMsg::separator_unknown(
+                inside.clone(),
+                outside.clone(),
+            ));
             None
         },
     }
@@ -181,10 +181,10 @@ pub(in crate::transform::tags_to_lanes) fn semantic_separator_to_lane(
                     }
                 }
             }
-            warnings.push(RoadMsg::SeparatorLocaleUnused {
-                inside: inside.clone(),
-                outside: outside.clone(),
-            });
+            warnings.push(TagsToLanesMsg::separator_locale_unused(
+                inside.clone(),
+                outside.clone(),
+            ));
             Some(Lane::Separator {
                 markings: if *more_than_2_lanes {
                     Markings::new(vec![
@@ -222,10 +222,10 @@ pub(in crate::transform::tags_to_lanes) fn semantic_separator_to_lane(
         }),
         // Modal separation
         Separator::Modal { .. } => {
-            warnings.push(RoadMsg::SeparatorLocaleUnused {
-                inside: inside.clone(),
-                outside: outside.clone(),
-            });
+            warnings.push(TagsToLanesMsg::separator_locale_unused(
+                inside.clone(),
+                outside.clone(),
+            ));
             Some(Lane::Separator {
                 markings: Markings::new(vec![Marking {
                     style: Style::SolidLine,
@@ -236,10 +236,10 @@ pub(in crate::transform::tags_to_lanes) fn semantic_separator_to_lane(
         },
         // TODO: error return
         _ => {
-            warnings.push(RoadMsg::SeparatorUnknown {
-                inside: inside.clone(),
-                outside: outside.clone(),
-            });
+            warnings.push(TagsToLanesMsg::separator_unknown(
+                inside.clone(),
+                outside.clone(),
+            ));
             Some(Lane::Separator {
                 markings: Markings::new(vec![Marking {
                     style: Style::BrokenLine,


### PR DESCRIPTION
Use std::panic::Location to idenitfy error locations
Refactoring with thiserror, another crate, or without may cut down on boilerplate