### PR TITLE
Rust: Miscellaneous Fixes

### DIFF
--- a/data/spec-lanes.json
+++ b/data/spec-lanes.json
@@ -137,17 +137,7 @@
                 }
             },
             "width": {
-                "type": "object",
-                "description": "A lane width.",
-                "properties": {
-                    "value": {
-                        "type": "number",
-                        "description": "The average width of the lane in meters."
-                    },
-                    "source": {
-                        "$ref": "/schemas/source"
-                    }
-                }
+                "type": "number"
             },
             "source": {
                 "$ref": "/schemas/source"

--- a/data/tests.yml
+++ b/data/tests.yml
@@ -123,6 +123,20 @@
             color: white
       - type: shoulder
 
+- description: service road width
+  rust: false
+  skip_python: true
+  skip_kotlin: true
+  tags:
+    highway: "service"
+  driving_side: right
+  road:
+    highway: service
+    lanes:
+      - type: travel
+        designated: motor_vehicle
+        width: 7
+
 ## Netherlands
 
 # https://nl.wikipedia.org/wiki/Autoweg

--- a/rust/osm2lanes/Cargo.toml
+++ b/rust/osm2lanes/Cargo.toml
@@ -27,9 +27,10 @@ overpass = ["reqwest", "reqwest/blocking", "reqwest/json"]
 tests = ["serde_yaml"]
 
 [dev-dependencies]
-osm2lanes = { path = ".", features = ["tests"] }
 assert-json-diff = "2.0"
 criterion = { version = "0.3", features = ["html_reports"] }
+env_logger = "0.9"
+osm2lanes = { path = ".", features = ["tests"] }
 serde_json = "1"
 
 [lib]

--- a/rust/osm2lanes/src/test.rs
+++ b/rust/osm2lanes/src/test.rs
@@ -143,8 +143,11 @@ mod tests {
     use crate::road::{Lane, Marking, Printable, Road};
     use crate::tag::Highway;
     use crate::transform::{
-        lanes_to_tags, tags_to_lanes, LanesToTagsConfig, RoadError, RoadFromTags, TagsToLanesConfig,
+        lanes_to_tags, tags_to_lanes, LanesToTagsConfig, RoadError, RoadFromTags, RoadWarnings,
+        TagsToLanesConfig,
     };
+
+    static LOG_INIT: std::sync::Once = std::sync::Once::new();
 
     fn approx_eq<T: std::cmp::PartialEq>(left: &Option<T>, right: &Option<T>) -> bool {
         match (left, right) {
@@ -287,16 +290,19 @@ mod tests {
 
     impl RoadFromTags {
         /// Return a Road based upon a `RoadFromTags` with irrelevant parts filtered out.
-        fn into_filtered_road(self, test: &TestCase) -> Road {
-            Road {
-                lanes: self
-                    .road
-                    .lanes
-                    .into_iter()
-                    .filter(|lane| test.is_lane_enabled(lane))
-                    .collect(),
-                highway: self.road.highway,
-            }
+        fn into_filtered_road(self, test: &TestCase) -> (Road, RoadWarnings) {
+            (
+                Road {
+                    lanes: self
+                        .road
+                        .lanes
+                        .into_iter()
+                        .filter(|lane| test.is_lane_enabled(lane))
+                        .collect(),
+                    highway: self.road.highway,
+                },
+                self.warnings,
+            )
         }
     }
 
@@ -375,8 +381,15 @@ mod tests {
         }
     }
 
+    fn env_logger_init() {
+        LOG_INIT.call_once(|| {
+            env_logger::builder().is_test(true).init();
+        });
+    }
+
     #[test]
     fn test_from_data() {
+        env_logger_init();
         let tests = get_tests();
 
         assert!(
@@ -404,7 +417,7 @@ mod tests {
                             println!();
                             false
                         } else {
-                            let actual_road = road_from_tags.into_filtered_road(test);
+                            let (actual_road, warnings) = road_from_tags.into_filtered_road(test);
                             if actual_road.approx_eq(&expected_road) {
                                 true
                             } else {
@@ -415,6 +428,7 @@ mod tests {
                                 println!("Expected:");
                                 println!("    {}", stringify_lane_types(&expected_road));
                                 println!("    {}", stringify_directions(&expected_road));
+                                println!("{}", warnings);
                                 if stringify_lane_types(&actual_road)
                                     == stringify_lane_types(&expected_road)
                                     || stringify_directions(&actual_road)
@@ -453,6 +467,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip() {
+        env_logger_init();
         let tests = get_tests();
 
         assert!(
@@ -481,7 +496,7 @@ mod tests {
                     },
                 )
                 .unwrap();
-                let output_road = output_lanes.into_filtered_road(test);
+                let (output_road, _warnings) = output_lanes.into_filtered_road(test);
                 if input_road.approx_eq(&output_road) {
                     true
                 } else {

--- a/rust/osm2lanes/src/transform/tags_to_lanes/access_by_lane.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/access_by_lane.rs
@@ -1,0 +1,26 @@
+#[derive(Debug)]
+pub(in crate::transform::tags_to_lanes) enum Access {
+    None,
+    No,
+    Yes,
+    Designated,
+}
+
+impl std::str::FromStr for Access {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "" => Ok(Self::None),
+            "no" => Ok(Self::No),
+            "yes" => Ok(Self::Yes),
+            "designated" => Ok(Self::Designated),
+            _ => Err(s.to_owned()),
+        }
+    }
+}
+
+impl Access {
+    pub(in crate::transform::tags_to_lanes) fn split(lanes: &str) -> Result<Vec<Self>, String> {
+        lanes.split('|').map(str::parse).collect()
+    }
+}

--- a/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/mod.rs
@@ -13,6 +13,8 @@ use crate::transform::RoadFromTags;
 mod error;
 pub use error::TagsToLanesMsg;
 
+mod access_by_lane;
+
 mod modes;
 
 mod separator;

--- a/rust/osm2lanes/src/transform/tags_to_lanes/modes/mod.rs
+++ b/rust/osm2lanes/src/transform/tags_to_lanes/modes/mod.rs
@@ -1,11 +1,16 @@
 /// Modes of travel
+///
 mod bicycle;
 pub(super) use bicycle::bicycle;
+
 mod bus;
 pub(super) use bus::bus;
+
 mod foot_shoulder;
 pub(super) use foot_shoulder::foot_and_shoulder;
+
 mod parking;
 pub(super) use parking::parking;
+
 mod non_motorized;
 pub(super) use non_motorized::non_motorized;


### PR DESCRIPTION
- Update spec to simplify width
- Add example using the width spec
- Add log to tests
- Show warnings on test failures
- Refactor pipe separated access strings into own module