### PR TITLE
OSM Tags only as Tree

### DIFF
--- a/osm-tags/src/key.rs
+++ b/osm-tags/src/key.rs
@@ -1,49 +1,130 @@
+use std::borrow::Borrow;
+use std::ops::Deref;
+
 use kstring::KString;
 
-/// A representation for the key of an OSM tag
-///
+/// A part of in OSM tag key.
+/// Must never contain a `:`
 /// ```
-/// use osm_tags::TagKey;
-/// const example_key: TagKey = TagKey::from_static("example");
-/// assert_eq!(example_key.as_str(), "example");
-/// assert_eq!((example_key + "foo").as_str(), "example:foo");
+/// use osm_tags::TagKeyPart;
+/// const example_part: TagKeyPart = TagKeyPart::from_static("example");
+/// assert_eq!(example_part.as_str(), "example");
 /// ```
-#[allow(clippy::module_name_repetitions)]
-#[derive(Debug, Clone)]
-pub struct TagKey(KString);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TagKeyPart(KString);
 
-impl TagKey {
+impl TagKeyPart {
+    /// Must not contain a `:`, as this cannot be handle at const time
     #[must_use]
     pub const fn from_static(string: &'static str) -> Self {
         Self(KString::from_static(string))
     }
 
-    #[must_use]
-    pub fn from_ref(string: &str) -> Self {
-        Self(KString::from_ref(string))
-    }
-
+    /// Must not contain a `:`, as this cannot be handle at const time
     #[must_use]
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
 }
 
+impl Borrow<str> for TagKeyPart {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for TagKeyPart {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for TagKeyPart {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<&'static str> for TagKeyPart {
+    fn from(string: &'static str) -> Self {
+        Self::from_static(string)
+    }
+}
+
+impl std::ops::Add for TagKeyPart {
+    type Output = TagKey;
+    fn add(self, other: Self) -> Self::Output {
+        Self::Output::new([self, other])
+    }
+}
+
+impl std::ops::Add<&'static str> for TagKeyPart {
+    type Output = TagKey;
+    fn add(self, other: &'static str) -> Self::Output {
+        Self::Output::new([self, other.into()])
+    }
+}
+
+/// The key of an OSM tag stored as `:` separated parts
+///
+/// ```
+/// use osm_tags::TagKey;
+/// let example_key: TagKey = TagKey::from_ref("example:foo");
+/// assert_eq!(example_key.to_string(), "example:foo");
+/// ```
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Clone)]
+pub struct TagKey(pub(crate) Vec<TagKeyPart>);
+
+impl TagKey {
+    #[must_use]
+    pub fn new<C>(collection: C) -> Self
+    where
+        C: IntoIterator,
+        C::Item: Into<TagKeyPart>,
+    {
+        Self(collection.into_iter().map(Into::into).collect())
+    }
+
+    #[must_use]
+    pub fn from_ref(string: &str) -> Self {
+        Self(
+            string
+                .split(':')
+                .map(KString::from_ref)
+                .map(TagKeyPart)
+                .collect(),
+        )
+    }
+
+    #[must_use]
+    pub fn from_string(string: String) -> Self {
+        Self(
+            string
+                .split(':')
+                .map(KString::from_ref)
+                .map(TagKeyPart)
+                .collect(),
+        )
+    }
+}
+
 impl From<String> for TagKey {
     fn from(string: String) -> Self {
-        Self(KString::from_string(string))
+        Self::from_string(string)
     }
 }
 
 impl From<&String> for TagKey {
     fn from(string: &String) -> Self {
-        Self(KString::from_ref(string))
+        Self::from_ref(string)
     }
 }
 
-impl From<&'static str> for TagKey {
-    fn from(string: &'static str) -> Self {
-        Self::from_static(string)
+impl From<&str> for TagKey {
+    fn from(string: &str) -> Self {
+        Self::from_ref(string)
     }
 }
 
@@ -51,20 +132,26 @@ impl std::str::FromStr for TagKey {
     type Err = std::convert::Infallible;
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(KString::from_ref(s)))
+        Ok(Self::from_ref(s))
     }
 }
 
-impl AsRef<str> for TagKey {
-    fn as_ref(&self) -> &str {
-        self.as_str()
+impl From<TagKeyPart> for TagKey {
+    fn from(part: TagKeyPart) -> Self {
+        Self(vec![part])
+    }
+}
+
+impl ToString for TagKey {
+    fn to_string(&self) -> String {
+        self.0.join(":")
     }
 }
 
 impl std::ops::Add for TagKey {
     type Output = Self;
     fn add(self, other: Self) -> Self {
-        let val = format!("{}:{}", self.as_str(), other.as_str());
+        let val = format!("{}:{}", self.to_string(), other.to_string());
         Self::from(val)
     }
 }

--- a/osm-tags/src/key.rs
+++ b/osm-tags/src/key.rs
@@ -142,6 +142,12 @@ impl From<TagKeyPart> for TagKey {
     }
 }
 
+impl From<&TagKeyPart> for TagKey {
+    fn from(part: &TagKeyPart) -> Self {
+        Self(vec![part.to_owned()])
+    }
+}
+
 impl ToString for TagKey {
     fn to_string(&self) -> String {
         self.0.join(":")

--- a/osm-tags/src/key.rs
+++ b/osm-tags/src/key.rs
@@ -99,25 +99,8 @@ impl TagKey {
     }
 
     #[must_use]
-    pub fn from_string(string: String) -> Self {
-        Self(
-            string
-                .split(':')
-                .map(KString::from_ref)
-                .map(TagKeyPart)
-                .collect(),
-        )
-    }
-
-    #[must_use]
     pub fn parts(&self) -> &[TagKeyPart] {
         &self.0
-    }
-}
-
-impl From<String> for TagKey {
-    fn from(string: String) -> Self {
-        Self::from_string(string)
     }
 }
 
@@ -156,7 +139,7 @@ impl From<TagKeyPart> for TagKey {
 
 impl From<&TagKeyPart> for TagKey {
     fn from(part: &TagKeyPart) -> Self {
-        Self(vec![part.to_owned()])
+        Self(vec![part.clone()])
     }
 }
 
@@ -177,7 +160,7 @@ impl std::ops::Add for TagKey {
     type Output = Self;
     fn add(self, other: Self) -> Self {
         let val = format!("{}:{}", self.to_string(), other.to_string());
-        Self::from(val)
+        Self::from(&val)
     }
 }
 

--- a/osm-tags/src/key.rs
+++ b/osm-tags/src/key.rs
@@ -108,6 +108,11 @@ impl TagKey {
                 .collect(),
         )
     }
+
+    #[must_use]
+    pub fn parts(&self) -> &[TagKeyPart] {
+        &self.0
+    }
 }
 
 impl From<String> for TagKey {
@@ -124,6 +129,13 @@ impl From<&String> for TagKey {
 
 impl From<&str> for TagKey {
     fn from(string: &str) -> Self {
+        Self::from_ref(string)
+    }
+}
+
+// TODO: this seems like a hack
+impl From<&&str> for TagKey {
+    fn from(string: &&str) -> Self {
         Self::from_ref(string)
     }
 }
@@ -145,6 +157,13 @@ impl From<TagKeyPart> for TagKey {
 impl From<&TagKeyPart> for TagKey {
     fn from(part: &TagKeyPart) -> Self {
         Self(vec![part.to_owned()])
+    }
+}
+
+// TODO: this is a hidden clone, which is incorrect
+impl From<&TagKey> for TagKey {
+    fn from(key: &TagKey) -> Self {
+        key.clone()
     }
 }
 

--- a/osm-tags/src/osm.rs
+++ b/osm-tags/src/osm.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{TagKey, Tags};
+use crate::{TagKey, TagKeyPart, Tags};
 
-pub const ONEWAY: TagKey = TagKey::from_static("oneway");
-pub const HIGHWAY: TagKey = TagKey::from_static("highway");
-const CONSTRUCTION: TagKey = TagKey::from_static("construction");
-const PROPOSED: TagKey = TagKey::from_static("proposed");
+pub const ONEWAY: TagKeyPart = TagKeyPart::from_static("oneway");
+pub const HIGHWAY: TagKeyPart = TagKeyPart::from_static("highway");
+const CONSTRUCTION: TagKeyPart = TagKeyPart::from_static("construction");
+const PROPOSED: TagKeyPart = TagKeyPart::from_static("proposed");
 pub const LIFECYCLE: [TagKey; 3] = [HIGHWAY, CONSTRUCTION, PROPOSED];
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/osm-tags/src/osm.rs
+++ b/osm-tags/src/osm.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{TagKey, TagKeyPart, Tags};
+use crate::{TagKeyPart, Tags};
 
 pub const ONEWAY: TagKeyPart = TagKeyPart::from_static("oneway");
 pub const HIGHWAY: TagKeyPart = TagKeyPart::from_static("highway");
 const CONSTRUCTION: TagKeyPart = TagKeyPart::from_static("construction");
 const PROPOSED: TagKeyPart = TagKeyPart::from_static("proposed");
-pub const LIFECYCLE: [TagKey; 3] = [HIGHWAY, CONSTRUCTION, PROPOSED];
+pub const LIFECYCLE: [TagKeyPart; 3] = [HIGHWAY, CONSTRUCTION, PROPOSED];
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HighwayType {

--- a/osm2lanes-npm/src/lib.rs
+++ b/osm2lanes-npm/src/lib.rs
@@ -38,7 +38,7 @@ pub fn js_tags_to_lanes(val: &JsValue) -> JsValue {
 
     let mut tags = Tags::default();
     for (key, value) in input.key_values {
-        tags.checked_insert(key, value).unwrap();
+        tags.checked_insert(&key, value).unwrap();
     }
     let lanes = tags_to_lanes(&tags, &locale, &config).unwrap();
     JsValue::from_serde(&lanes).unwrap()

--- a/osm2lanes/src/test.rs
+++ b/osm2lanes/src/test.rs
@@ -515,7 +515,7 @@ mod tests {
                 println!("    {}", stringify_lane_types(&input_road));
                 println!("    {}", stringify_directions(&input_road));
                 println!("Normalized OSM tags:");
-                for [k, v] in tags.to_str_pairs() {
+                for (k, v) in tags.to_str_pairs() {
                     println!("    {} = {}", k, v);
                 }
                 println!("Got:");

--- a/osm2lanes/src/transform/mod.rs
+++ b/osm2lanes/src/transform/mod.rs
@@ -1,22 +1,22 @@
 use crate::locale::DrivingSide;
 use crate::road::{Designated, Direction, Lane};
-use crate::tag::TagKey;
 
 mod error;
 pub use error::{RoadError, RoadFromTags, RoadWarnings};
 
 mod tags_to_lanes;
+use osm_tags::TagKeyPart;
 pub use tags_to_lanes::{tags_to_lanes, Config as TagsToLanesConfig, Infer, TagsToLanesMsg};
 
 mod lanes_to_tags;
 pub use lanes_to_tags::{lanes_to_tags, Config as LanesToTagsConfig, LanesToTagsMsg};
 
 pub mod tags {
-    use crate::tag::TagKey;
+    use osm_tags::TagKeyPart;
 
-    pub const CYCLEWAY: TagKey = TagKey::from_static("cycleway");
-    pub const SIDEWALK: TagKey = TagKey::from_static("sidewalk");
-    pub const SHOULDER: TagKey = TagKey::from_static("shoulder");
+    pub const CYCLEWAY: TagKeyPart = TagKeyPart::from_static("cycleway");
+    pub const SIDEWALK: TagKeyPart = TagKeyPart::from_static("sidewalk");
+    pub const SHOULDER: TagKeyPart = TagKeyPart::from_static("shoulder");
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -51,17 +51,17 @@ impl std::convert::From<DrivingSide> for WaySide {
     }
 }
 
-impl std::convert::From<DrivingSide> for TagKey {
+impl std::convert::From<DrivingSide> for TagKeyPart {
     fn from(side: DrivingSide) -> Self {
         match side {
-            DrivingSide::Right => Self::from("right"),
-            DrivingSide::Left => Self::from("left"),
+            DrivingSide::Right => Self::from_static("right"),
+            DrivingSide::Left => Self::from_static("left"),
         }
     }
 }
 
 impl DrivingSide {
-    fn tag(self) -> TagKey {
+    fn tag(self) -> TagKeyPart {
         self.into()
     }
 }

--- a/osm2lanes/src/transform/tags_to_lanes/counts.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/counts.rs
@@ -1,6 +1,8 @@
+use osm_tags::{TagKeyPart, Tags};
+
 use super::{Infer, Oneway, TagsNumeric};
 use crate::locale::Locale;
-use crate::tag::{Highway, TagKey, Tags};
+use crate::tag::Highway;
 use crate::transform::tags_to_lanes::modes::BusLaneCount;
 use crate::transform::{RoadWarnings, TagsToLanesMsg};
 
@@ -43,7 +45,7 @@ impl Counts {
             (None, None) => Infer::Default(false),
             (Some(()), Some(false)) => {
                 warnings.push(TagsToLanesMsg::ambiguous_tags(
-                    tags.subset(&[LANES + "both_ways", CENTRE_TURN_LANE]),
+                    tags.subset(&[LANES + "both_ways", CENTRE_TURN_LANE.into()]),
                 ));
                 Infer::Default(true)
             },
@@ -201,7 +203,7 @@ impl Counts {
     }
 }
 
-const LANES: TagKey = TagKey::from_static("lanes");
+const LANES: TagKeyPart = TagKeyPart::from_static("lanes");
 
 /// `lanes` and directional `lanes:*` scheme, see <https://wiki.openstreetmap.org/wiki/Key:lanes>
 pub(in crate::transform::tags_to_lanes) struct LanesDirectionScheme {
@@ -240,7 +242,7 @@ impl LanesDirectionScheme {
     }
 }
 
-const CENTRE_TURN_LANE: TagKey = TagKey::from_static("centre_turn_lane");
+const CENTRE_TURN_LANE: TagKeyPart = TagKeyPart::from_static("centre_turn_lane");
 pub(in crate::transform::tags_to_lanes) struct CentreTurnLaneScheme(pub Option<bool>);
 impl CentreTurnLaneScheme {
     /// Parses and validates the `centre_turn_lane` tag and emits a deprecation warning.

--- a/osm2lanes/src/transform/tags_to_lanes/error.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/error.rs
@@ -87,7 +87,7 @@ impl TagsToLanesMsg {
         TagsToLanesMsg {
             location: Location::caller(),
             issue: TagsToLanesIssue::Deprecated {
-                deprecated_tags: Tags::from_str_pair([key.into().as_str(), val]),
+                deprecated_tags: Tags::from_str_pair([&key.into().to_string(), val]),
                 suggested_tags: None,
             },
         }
@@ -124,7 +124,7 @@ impl TagsToLanesMsg {
             location: Location::caller(),
             issue: TagsToLanesIssue::Unsupported {
                 description: None,
-                tags: Some(Tags::from_str_pair([key.into().as_str(), val])),
+                tags: Some(Tags::from_str_pair([&key.into().to_string(), val])),
             },
         }
     }
@@ -160,7 +160,7 @@ impl TagsToLanesMsg {
             location: Location::caller(),
             issue: TagsToLanesIssue::Unimplemented {
                 description: None,
-                tags: Some(Tags::from_str_pair([key.into().as_str(), val])),
+                tags: Some(Tags::from_str_pair([&key.into().to_string(), val])),
             },
         }
     }
@@ -184,7 +184,7 @@ impl TagsToLanesMsg {
             location: Location::caller(),
             issue: TagsToLanesIssue::Ambiguous {
                 description: None,
-                tags: Some(Tags::from_str_pair([key.into().as_str(), val])),
+                tags: Some(Tags::from_str_pair([&key.into().to_string(), val])),
             },
         }
     }

--- a/osm2lanes/src/transform/tags_to_lanes/mod.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/mod.rs
@@ -31,18 +31,17 @@ pub use infer::Infer;
 trait TagsNumeric {
     fn get_parsed<K, T>(&self, key: K, warnings: &mut RoadWarnings) -> Option<T>
     where
-        K: AsRef<str>,
-        TagKey: From<K>,
+        K: Into<TagKey>,
         T: std::str::FromStr;
 }
 
 impl TagsNumeric for Tags {
     fn get_parsed<K, T>(&self, key: K, warnings: &mut RoadWarnings) -> Option<T>
     where
-        K: AsRef<str>,
-        TagKey: From<K>,
+        K: Into<TagKey>,
         T: std::str::FromStr,
     {
+        let key: TagKey = key.into();
         self.get(&key).and_then(|val| {
             if let Ok(w) = val.parse::<T>() {
                 Some(w)

--- a/osm2lanes/src/transform/tags_to_lanes/modes/bicycle.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/modes/bicycle.rs
@@ -23,8 +23,8 @@ enum VariantError {
 impl From<VariantError> for TagsToLanesMsg {
     fn from(e: VariantError) -> Self {
         match e {
-            VariantError::UnknownVariant(key, val) => Self::unsupported_tag(key, &val),
-            VariantError::UnimplementedVariant(key, val) => Self::unimplemented_tag(key, &val),
+            VariantError::UnknownVariant(key, val) => Self::unsupported_tag(&key, &val),
+            VariantError::UnimplementedVariant(key, val) => Self::unimplemented_tag(&key, &val),
         }
     }
 }

--- a/osm2lanes/src/transform/tags_to_lanes/modes/bus/busway.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/modes/bus/busway.rs
@@ -1,11 +1,12 @@
+use osm_tags::{TagKey, TagKeyPart, Tags};
+
 use crate::locale::Locale;
 use crate::road::Direction;
-use crate::tag::{TagKey, Tags};
 use crate::transform::tags_to_lanes::{Infer, Oneway, RoadBuilder};
 use crate::transform::{RoadWarnings, TagsToLanesMsg};
 
-const BUSWAY: TagKey = TagKey::from_static("busway");
-const ONEWAY: TagKey = TagKey::from_static("oneway");
+const BUSWAY: TagKeyPart = TagKeyPart::from_static("busway");
+const ONEWAY: TagKeyPart = TagKeyPart::from_static("oneway");
 
 #[derive(Debug, PartialEq)]
 pub(in crate::transform::tags_to_lanes) enum Variant {
@@ -43,9 +44,9 @@ enum Lane {
 
 fn get_bus_lane<T>(tags: &Tags, key: T, warnings: &mut RoadWarnings) -> Lane
 where
-    T: AsRef<str>,
-    TagKey: From<T>,
+    T: Into<TagKey>,
 {
+    let key: TagKey = key.into();
     match tags.get(&key) {
         None => Lane::None,
         Some("lane") => Lane::Lane,
@@ -82,8 +83,8 @@ impl Scheme {
             (Lane::Lane, Oneway::Yes) => Variant::Forward,
             (Lane::Opposite, Oneway::No) => {
                 warnings.push(TagsToLanesMsg::unsupported_tags(tags.subset(&[
-                    BUSWAY,
-                    ONEWAY,
+                    BUSWAY.into(),
+                    ONEWAY.into(),
                     ONEWAY + "bus",
                 ])));
                 Variant::None
@@ -129,8 +130,8 @@ impl Scheme {
             }
             if let Variant::Forward | Variant::Backward = busway_root {
                 warnings.push(TagsToLanesMsg::ambiguous_tags(tags.subset(&[
-                    BUSWAY,
-                    ONEWAY,
+                    BUSWAY.into(),
+                    ONEWAY.into(),
                     ONEWAY + "bus",
                     BUSWAY + "both",
                 ])));
@@ -140,8 +141,8 @@ impl Scheme {
         {
             if busway_root != Variant::None && busway_root != busway_forward_backward {
                 warnings.push(TagsToLanesMsg::ambiguous_tags(tags.subset(&[
-                    BUSWAY,
-                    ONEWAY,
+                    BUSWAY.into(),
+                    ONEWAY.into(),
                     ONEWAY + "bus",
                     busway_forward_key(),
                     busway_backward_key(),

--- a/osm2lanes/src/transform/tags_to_lanes/modes/bus/mod.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/modes/bus/mod.rs
@@ -1,6 +1,5 @@
 use crate::locale::Locale;
 use crate::road::Designated;
-use crate::tag::{TagKey, Tags};
 use crate::transform::tags_to_lanes::{
     Access, Infer, LaneBuilder, LaneBuilderError, LaneDependentAccess, Oneway, RoadBuilder,
     TagsNumeric, TagsToLanesMsg,
@@ -9,8 +8,9 @@ use crate::transform::RoadWarnings;
 
 mod busway;
 use busway::{busway, Scheme as BuswayScheme};
+use osm_tags::{TagKeyPart, Tags};
 
-const LANES: TagKey = TagKey::from_static("lanes");
+const LANES: TagKeyPart = TagKeyPart::from_static("lanes");
 
 impl LaneBuilder {
     #[allow(clippy::unnecessary_wraps)]
@@ -61,14 +61,12 @@ pub(in crate::transform::tags_to_lanes) fn bus(
     // https://wiki.openstreetmap.org/wiki/Bus_lanes
     // 3 schemes, for simplicity we only allow one at a time
     match (
-        tags.tree().get("busway").is_some(),
-        tags.tree()
-            .get("lanes:bus")
-            .or_else(|| tags.tree().get("lanes:psv"))
+        tags.get_node("busway").is_some(),
+        tags.get_node("lanes:bus")
+            .or_else(|| tags.get_node("lanes:psv"))
             .is_some(),
-        tags.tree()
-            .get("bus:lanes")
-            .or_else(|| tags.tree().get("psv:lanes"))
+        tags.get_node("bus:lanes")
+            .or_else(|| tags.get_node("psv:lanes"))
             .is_some(),
     ) {
         (false, false, false) => {},

--- a/osm2lanes/src/transform/tags_to_lanes/modes/foot_shoulder.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/modes/foot_shoulder.rs
@@ -58,7 +58,7 @@ impl Sidewalk {
         warnings: &mut RoadWarnings,
     ) -> Result<(Self, Self), TagsToLanesMsg> {
         let err = Err(TagsToLanesMsg::unsupported_tags(tags.subset(&[
-            SIDEWALK,
+            SIDEWALK.into(),
             SIDEWALK + locale.driving_side.tag(),
             SIDEWALK + locale.driving_side.opposite().tag(),
         ])));
@@ -75,7 +75,7 @@ impl Sidewalk {
                 "no" => (Sidewalk::No, Sidewalk::No),
                 "yes" => {
                     warnings.push(TagsToLanesMsg::ambiguous_tags(
-                        tags.subset(&[SIDEWALK, SIDEWALK + "both"]),
+                        tags.subset(&[SIDEWALK.into(), SIDEWALK + "both"]),
                     ));
                     (Sidewalk::Yes, Sidewalk::Yes)
                 },

--- a/osm2lanes/src/transform/tags_to_lanes/road.rs
+++ b/osm2lanes/src/transform/tags_to_lanes/road.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::iter;
 
+use osm_tags::{TagKeyPart, Tags};
+
 use super::infer::Infer;
 use super::oneway::Oneway;
 use super::separator::{
@@ -14,7 +16,7 @@ use crate::road::{
     AccessAndDirection as LaneAccessAndDirection, AccessByType as LaneAccessByType, Designated,
     Direction, Lane,
 };
-use crate::tag::{Access as AccessValue, Highway, TagKey, Tags, HIGHWAY, LIFECYCLE};
+use crate::tag::{Access as AccessValue, Highway, HIGHWAY, LIFECYCLE};
 use crate::transform::error::{RoadError, RoadWarnings};
 use crate::transform::tags_to_lanes::counts::{CentreTurnLaneScheme, Counts};
 use crate::transform::tags_to_lanes::modes::BusLaneCount;
@@ -186,7 +188,7 @@ impl RoadBuilder {
             Designated::Motor
         };
 
-        const MAXSPEED: TagKey = TagKey::from_static("maxspeed");
+        const MAXSPEED: TagKeyPart = TagKeyPart::from_static("maxspeed");
         let max_speed = match tags.get(MAXSPEED).map(str::parse::<Speed>).transpose() {
             Ok(max_speed) => max_speed,
             Err(e) => {


### PR DESCRIPTION
An initial step towards a better tree structure.
Generics removed for simplicity
Successful tree-only data store