### PR TITLE
Deserializing Tags Crashing on Website

### DIFF
--- a/osm-tags/src/lib.rs
+++ b/osm-tags/src/lib.rs
@@ -323,14 +323,10 @@ impl<'de> serde::de::Visitor<'de> for TagsVisitor {
         M: serde::de::MapAccess<'de>,
     {
         let mut tags = Tags::default();
-        // For when this becomes important:
-        //let mut map = Tags::with_capacity(access.size_hint().unwrap_or(0));
-
         while let Some((key, value)) = access.next_entry::<String, String>()? {
-            // TODO
-            tags.checked_insert(&key, value).unwrap();
+            // Overpass sometimes returns duplicate tags
+            let _ignored = tags.checked_insert(&key, value);
         }
-
         Ok(tags)
     }
 }


### PR DESCRIPTION
It appears to be due to a duplication in tags in overpass' JSON response.

e.g. given way 3600044874
ISO3166-2=IT-21 is repeated 4 times.
The cause is unclear.