### PR TITLE
Add a button to generate example test YAML from the web app

### DIFF
--- a/osm2lanes-web/Cargo.toml
+++ b/osm2lanes-web/Cargo.toml
@@ -32,6 +32,7 @@ wasm-bindgen = "0.2"
 wee_alloc = { version = "0.4", optional = true }
 yew = "0.19"
 gloo-worker = { git = "https://github.com/futursolo/gloo", rev = "a2101e166260294292c8121fdb8ed883dae62ed8" }
+serde_yaml = "0.9"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/osm2lanes-web/src/lib.rs
+++ b/osm2lanes-web/src/lib.rs
@@ -389,7 +389,7 @@ fn generate_test_yaml(
     locale: &Locale,
     way_id: Option<i64>,
 ) -> String {
-    use osm2lanes::test::{Expected, TestCase};
+    use osm2lanes::test::TestCase;
 
     let test = TestCase {
         way_id,
@@ -400,7 +400,7 @@ fn generate_test_yaml(
         driving_side: locale.driving_side,
         iso_3166_2: locale.iso_3166_2_subdivision.clone(),
         tags: Tags::from_str(tags).unwrap_or_else(|_| Tags::default()),
-        expected: Expected::Road(road.unwrap_or_else(|| Road::empty())),
+        road: road.unwrap_or_else(|| Road::empty()),
         rust: None,
     };
     // TODO Strip out road's name, ref, and other things we don't test for?

--- a/osm2lanes-web/src/lib.rs
+++ b/osm2lanes-web/src/lib.rs
@@ -405,16 +405,21 @@ fn generate_test_yaml(
     };
     // TODO Strip out road's name, ref, and other things we don't test for?
     // TODO Based on checkboxes, strip out separators
-    let raw = serde_yaml::to_string(&test).unwrap();
+    let raw = serde_yaml::to_string(&vec![test]).unwrap();
 
-    // serde_yaml explicitly lists "field: null" for None values. Filter these out, to match the
-    // style of the test YAML.
     let mut output = String::new();
     for line in raw.lines() {
+        // serde_yaml explicitly lists "field: null" for None values. Filter these out, to match the
+        // style of the test YAML.
         if !line.ends_with(": null") {
             output.push_str(line);
             output.push_str("\n");
         }
     }
+
+    // Valid YAML in the test needs the item to start with a '-'. Serializing vec![test] indents,
+    // but doesn't add the hyphen. Do that manually.
+    output.replace_range(0..1, "-");
+
     output
 }

--- a/osm2lanes/Cargo.toml
+++ b/osm2lanes/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.11", optional = true, features = [
 serde = { version = "1", optional = true, features = [
     "derive",
 ] } # Crate interface is serde compatible
-serde_yaml = { version = "0.8", optional = true } # Parsing test data
+serde_yaml = { version = "0.9", optional = true } # Parsing test data
 
 [features]
 serde = ["dep:serde", "osm-tags/serde", "osm-tag-schemes/serde"]

--- a/osm2lanes/src/road/mod.rs
+++ b/osm2lanes/src/road/mod.rs
@@ -1,4 +1,4 @@
-use osm_tag_schemes::{Highway, Lit, Smoothness, TrackType};
+use osm_tag_schemes::{Highway, HighwayType, Lit, Smoothness, TrackType};
 
 use crate::locale::Locale;
 use crate::metric::Metre;
@@ -31,13 +31,25 @@ pub struct Road {
 }
 
 impl Road {
+    /// A road without any metadata or lanes filled out
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            name: None,
+            r#ref: None,
+            highway: Highway::active(HighwayType::UnknownRoad),
+            lit: None,
+            tracktype: None,
+            smoothness: None,
+            lanes: Vec::new(),
+        }
+    }
+
     #[must_use]
     pub fn has_separators(&self) -> bool {
         self.lanes.iter().any(Lane::is_separator)
     }
-}
 
-impl Road {
     /// Width in metres
     #[must_use]
     pub fn width(&self, locale: &Locale) -> Metre {

--- a/osm2lanes/src/test.rs
+++ b/osm2lanes/src/test.rs
@@ -28,7 +28,7 @@ pub struct TestCase {
     pub description: Option<String>,
 
     /// List as a named example in the web app, with the given name
-    example: Option<String>,
+    pub example: Option<String>,
 
     // Config and Locale
     pub driving_side: DrivingSide,


### PR DESCRIPTION
If you want to add a test case to the .yaml today, you have to:

- copy paste an existing example, then change some things about it
- decide where in the .yaml file it should go (based on comments about organization)

This PR mostly fixes the first. You can use the web app, get the current output, and generate the YAML. You have to manually fix it up -- usually because the expected output is wrong -- but this is much faster workflow.
![Screenshot from 2022-11-01 11-58-35](https://user-images.githubusercontent.com/1664407/199228172-20596908-3939-4a61-9013-1c962bdf8ea7.png)
