### PR TITLE
Handle sidewalk=separate and none. Closes #249

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ TODO:
 - More bus and taxi lane examples
 - Trunk/Motorway/Highway
 
+### Parallel ways
+
+Sidewalks, cyclepaths, and roads split into dual carriageways are some examples in OSM where there are multiple parallel ways close together. Human judgment may be to group them into one logical road. `osm2lanes` does not attempt to do this; it just parses one OSM way at a time. See [osm2streets](https://github.com/a-b-street/osm2streets) for higher-level grouping.
+
 ## Web demo
 
 The web demo at https://a-b-street.github.io/osm2lanes provides an easy way to test OSM tags and see the generated results.

--- a/data/tests.yml
+++ b/data/tests.yml
@@ -385,6 +385,36 @@
         direction: forward
         designated: motor_vehicle
 
+- description: sidewalk=none
+  tags:
+    highway: "road"
+    lanes: "1"
+    oneway: "yes"
+    sidewalk: "none"
+  driving_side: left
+  road:
+    highway: road
+    lanes:
+      - type: travel
+        direction: forward
+        designated: motor_vehicle
+  rust:
+    expect_warnings: true
+
+- description: sidewalk=separate
+  tags:
+    highway: "road"
+    lanes: "1"
+    oneway: "yes"
+    sidewalk: "separate"
+  driving_side: left
+  road:
+    highway: road
+    lanes:
+      - type: travel
+        direction: forward
+        designated: motor_vehicle
+
 - description: sidewalk=both
   tags:
     highway: "road"


### PR DESCRIPTION
This PR handles `sidewalk=separate` by silently ignoring it and not adding a sidewalk, because it's not the job of osm2lanes to figure out parallel ways. And it handles `sidewalk=none` by treating it the same as `no` and adding a deprecated warning.